### PR TITLE
PdfPreview unhandled exception when popped

### DIFF
--- a/printing/lib/src/pdf_preview.dart
+++ b/printing/lib/src/pdf_preview.dart
@@ -120,6 +120,7 @@ class _PdfPreviewState extends State<PdfPreview> {
 
     var pageNum = 0;
     await for (final PdfRaster page in Printing.raster(_doc, dpi: dpi)) {
+      if (!mounted) return;
       setState(() {
         if (pages.length <= pageNum) {
           pages.add(_PdfPreviewPage(


### PR DESCRIPTION
When route which contains PdfPreview is popped, we got a:
Unhandled Exception: setState() called after dispose()

The solution is to add if (!mounted) return; in the file pdf_preview.dart in the function _raster() just after await for (final PdfRaster page in Printing.raster(_doc, dpi: dpi)) {